### PR TITLE
Don't instantiate Camera unless needed

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,5 +30,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,12 +11,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion project.hasProperty('compileSdkVersion') ? project.compileSdkVersion : 23
+    buildToolsVersion project.hasProperty('buildToolsVersion') ? project.buildToolsVersion : "23.0.1"
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion project.hasProperty('minSdkVersion') ? project.minSdkVersion : 16
+        targetSdkVersion project.hasProperty('targetSdkVersion') ? project.targetSdkVersion : 22
         versionCode 1
         versionName "1.0"
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,5 +30,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.12.+'
+    compile 'com.facebook.react:react-native:+'
 }

--- a/android/src/main/java/com/lcd344/reactnativeflash/RNFlash.java
+++ b/android/src/main/java/com/lcd344/reactnativeflash/RNFlash.java
@@ -30,7 +30,6 @@ public class RNFlash extends ReactContextBaseJavaModule {
 	public RNFlash(ReactApplicationContext reactContext) {
 		super(reactContext);
 		mReactContext = reactContext;
-		mCamera = getCamera();
 	}
 
 
@@ -44,45 +43,44 @@ public class RNFlash extends ReactContextBaseJavaModule {
 
 		if (mCamera == null) {
 			try {
-				camera = Camera.open();
-				return camera;
+				mCamera = Camera.open();
 			} catch (RuntimeException e) {
 				Log.e("Camera Error. Failed to Open. Error: ", e.getMessage());
 			}
 		}
 
-		return null;
+		return mCamera;
 	}
 
 	@ReactMethod
 	public void turnOnFlash() {
-
+    Camera camera = getCamera();
 		Parameters params;
 
-		if (mCamera == null || !mReactContext.getApplicationContext().getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_FLASH)) {
+		if (camera == null || !mReactContext.getApplicationContext().getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_FLASH)) {
 			return;
 		}
 
-		params = mCamera.getParameters();
+		params = camera.getParameters();
 		params.setFlashMode(Parameters.FLASH_MODE_TORCH);
-		mCamera.setParameters(params);
-		mCamera.startPreview();
+		camera.setParameters(params);
+		camera.startPreview();
 	}
 
 
 	@ReactMethod
 	public void turnOffFlash() {
-
+    Camera camera = getCamera();
 		Parameters params;
 
-		if (mCamera == null || !mReactContext.getApplicationContext().getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_FLASH)) {
+		if (camera == null || !mReactContext.getApplicationContext().getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_FLASH)) {
 			return;
 		}
 
-		params = mCamera.getParameters();
+		params = camera.getParameters();
 		params.setFlashMode(Parameters.FLASH_MODE_OFF);
-		mCamera.setParameters(params);
-		mCamera.stopPreview();
+		camera.setParameters(params);
+		camera.stopPreview();
 	}
 
 	@ReactMethod

--- a/android/src/main/java/com/lcd344/reactnativeflash/ReactNativeFlashPackage.java
+++ b/android/src/main/java/com/lcd344/reactnativeflash/ReactNativeFlashPackage.java
@@ -20,11 +20,6 @@ public class ReactNativeFlashPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }

--- a/react-native-flash.podspec
+++ b/react-native-flash.podspec
@@ -1,0 +1,19 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
+  s.platforms    = { :ios => "9.0" }
+
+  s.source       = { :git => "https://github.com/KrowdBeat/react-native-flash.git", :tag => s.version }
+  s.source_files  = "ios/**/*.{h,m}"
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
I'm using this module to check if flash is supported on device. But then using react-native-camera to actually use it. Right now the module instantiates Camera on init which blocks it from being used elsewhere in the program. I know it's an odd use case but the fix is simple so I hope you'll accept the patch!